### PR TITLE
Added MFU calculations for RWKV according to appendix C of RWKV paper

### DIFF
--- a/modeling_rwkv.py
+++ b/modeling_rwkv.py
@@ -531,7 +531,13 @@ class RWKV(nn.Module):
         flops_per_iter = flops_per_fwdbwd * fwdbwd_per_iter
         # express our flops throughput as ratio of A100 bfloat16 peak flops
         flops_achieved = flops_per_iter * (1.0/dt) # per second
-        flops_promised = 312e12 # A100 GPU bfloat16 peak flops is 312 TFLOPS
+        # https://www.nvidia.com/content/dam/en-zz/Solutions/Data-Center/a100/pdf/nvidia-a100-datasheet.pdf
+        if cfg.dtype == 'bfloat16':
+            flops_promised = 312e12 # A100 GPU bfloat16 peak flops is 312 TFLOPS
+        elif cfg.dtype == 'float16':
+            flops_promised = 312e12 # A100 GPU float16 peak flops is 312 TFLOPS
+        else: #dtype == float32
+            flops_promised = 19.5e12 # A100 GPU float32 peak flops is 19.5 TFLOPS
         mfu = flops_achieved / flops_promised
         return mfu
 

--- a/modeling_rwkv.py
+++ b/modeling_rwkv.py
@@ -519,16 +519,15 @@ class RWKV(nn.Module):
         return optimizer
 
     def estimate_mfu(self, fwdbwd_per_iter, dt):
-        ## since RWKV is not a Transformer-based model, MFU is not applicable here
-        return -1
         """ estimate model flops utilization (MFU) in units of A100 bfloat16 peak FLOPS """
         # first estimate the number of flops we do per iteration.
-        # see PaLM paper Appendix B as ref: https://arxiv.org/abs/2204.02311
-        N = self.get_num_params()
+        # see RWKV paper Appendix C as ref: https://arxiv.org/abs/2305.13048
         cfg = self.config
-        L, H, Q, T = cfg.n_layer, cfg.n_head, cfg.n_embd//cfg.n_head, cfg.block_size
-        flops_per_token = 6*N + 12*L*H*Q*T
-        flops_per_fwdbwd = flops_per_token * T
+        L, V, D = cfg.n_layer, cfg.vocab_size, cfg.n_embd
+        # Note there is a typo in the RWKV paper. Forward pass is 2*fn, forward
+        # and backward is 6*fn.
+        flops_per_token = 2*(V*D + 13*(V**2)*L)
+        flops_per_fwdbwd = 3*flops_per_token
         flops_per_iter = flops_per_fwdbwd * fwdbwd_per_iter
         # express our flops throughput as ratio of A100 bfloat16 peak flops
         flops_achieved = flops_per_iter * (1.0/dt) # per second


### PR DESCRIPTION
I have added MFU calculations like seen in nanoGPT for our RWKV models.
I calculated these according to appendix C of the RWKV paper https://arxiv.org/pdf/2305.13048.pdf.